### PR TITLE
remove deprecated `typeof-compare`

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -63,7 +63,6 @@
         "variable-declaration": "nospace"
       }
     ],
-    "typeof-compare": true,
     "unified-signatures": true,
     "variable-name": false,
     "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"],


### PR DESCRIPTION
`typeof-compare` is deprecated. Starting from TypeScript 2.2 the compiler includes this check which makes this rule redundant.
https://github.com/palantir/tslint/issues/2187