### PR TITLE
Codelyzer is downloaded into the node_modules folder of tslint-angular

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["codelyzer"],
+  "rulesDirectory": ["node_modules/codelyzer"],
   "rules": {
     "arrow-return-shorthand": true,
     "callable-types": true,


### PR DESCRIPTION
So it should point to that subdirectory right?