### PR TITLE
fix: remove no-use-before-declare

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -43,7 +43,6 @@
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,
-    "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],


### PR DESCRIPTION
Tslint recommends against using this rule, especially in environments where you aren't using var 

> Since most modern TypeScript doesn’t use var, this rule is generally discouraged and is kept around for legacy purposes. It is slow to compute, is not enabled in the built-in configuration presets, and should not be used to inform TSLint design decisions.

https://palantir.github.io/tslint/rules/no-use-before-declare/

PR to remove in Angular: https://github.com/angular/angular/pull/30288
PR to remove in NX: https://github.com/nrwl/nx/pull/1267